### PR TITLE
Disable IPV6 and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ You can easily build a HTTP proxy server using this.
 
 ## Try this container
 
+### IPV6
+
+By default IPV6 is disable, to enable it, in `nginx.conf` remove or set to true the following property
+
+```
+ipv6=off;
+```
+
 ### Requirement packages
 
 - Docker

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,7 +16,7 @@ http {
     access_log /dev/stdout;
     error_log  /dev/stderr;
 
-    resolver 8.8.8.8;
+    resolver 8.8.8.8    ipv6=off;
 
     proxy_connect;
     proxy_connect_allow           443 563;


### PR DESCRIPTION
In some network's setup ipv6 is not enabled and this causes a random 502
error to solve this we disable by default ipv6 and added instructions to
the README with instruction to enble it